### PR TITLE
Bugfix: onError function not called on error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ export default class ProgressiveImage extends React.Component<Props, State> {
     this.image = image;
     image.onload = this.onLoad;
     image.onerror = () => {
-      this.onError;
+      this.onError();
       return;
       // this.handleImageRetries(image);
     };

--- a/src/index.js
+++ b/src/index.js
@@ -95,8 +95,8 @@ export default class ProgressiveImage extends React.Component<Props, State> {
     const image = new Image();
     this.image = image;
     image.onload = this.onLoad;
-    image.onerror = () => {
-      this.onError();
+    image.onerror = errorEvent => {
+      this.onError(errorEvent);
       return;
       // this.handleImageRetries(image);
     };


### PR DESCRIPTION
The passed-in onError function was not properly called when an error occured.