### PR TITLE
fix: add children type to make it compatible with React 18

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,31 +1,30 @@
 declare module 'react-progressive-graceful-image' {
-  export interface ProgressiveImageProps {
-    delay?: number;
-    onError?: (errorEvent: Event) => void;
-    placeholder: string;
-    src: string;
-    srcSetData?: {
-      srcSet: string;
-      sizes: string;
-    };
-    noRetry?: boolean;
-    noLazyLoad?: boolean;
-    rootMargin?: string;
-    threshold?: Array;
-    children?: (src: string, loading: boolean) => React.ReactNode;
-  }
+	type srcSetData = {
+		srcSet: string;
+		sizes: string;
+	};
 
-  export interface ProgressiveImageState {
-    image: string;
-    loading: boolean;
-    srcSetData?: {
-      srcSet: string;
-      sizes: string;
-    }; 
-  }
+	export interface ProgressiveImageProps {
+		delay?: number;
+		onError?: (errorEvent: Event) => void;
+		placeholder: string;
+		src: string;
+		srcSetData?: srcSetData;
+		noRetry?: boolean;
+		noLazyLoad?: boolean;
+		rootMargin?: string;
+		threshold?: Array;
+		children?: (src: string, loading: boolean, srcSetData: srcSetData) => React.ReactNode;
+	}
 
-  export default class ProgressiveImage extends React.Component<
-    ProgressiveImageProps,
-    ProgressiveImageState
-  > {}
+	export interface ProgressiveImageState {
+		image: string;
+		loading: boolean;
+		srcSetData?: srcSetData;
+	}
+
+	export default class ProgressiveImage extends React.Component<
+		ProgressiveImageProps,
+		ProgressiveImageState
+	> {}
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -12,6 +12,7 @@ declare module 'react-progressive-graceful-image' {
     noLazyLoad?: boolean;
     rootMargin?: string;
     threshold?: Array;
+    children?: (src: string, loading: boolean) => React.ReactNode;
   }
 
   export interface ProgressiveImageState {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,7 +14,7 @@ declare module 'react-progressive-graceful-image' {
 		noLazyLoad?: boolean;
 		rootMargin?: string;
 		threshold?: Array;
-		children?: (src: string, loading: boolean, srcSetData: srcSetData) => React.ReactNode;
+		children?: (src: string, loading?: boolean, srcSetData?: srcSetData) => React.ReactNode;
 	}
 
 	export interface ProgressiveImageState {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,7 +14,7 @@ declare module 'react-progressive-graceful-image' {
 		noLazyLoad?: boolean;
 		rootMargin?: string;
 		threshold?: Array;
-		children?: (src: string, loading?: boolean, srcSetData?: srcSetData) => React.ReactNode;
+		children?: (src: string, loading?: boolean, srcSetData?: srcSetData) => React.Node;
 	}
 
 	export interface ProgressiveImageState {


### PR DESCRIPTION
This PR adds children typing to the component due to the recent removal of implicit children definition in React 18 as stated in issue https://github.com/sanishkr/react-progressive-graceful-image/issues/6.